### PR TITLE
Fix order of executing things

### DIFF
--- a/packages/stash-it/jsr.json
+++ b/packages/stash-it/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@stash-it/stash-it",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "exports": "./mod.ts",
   "publish": {
     "include": ["package.json", "README.md", "mod.ts", "src/**/*.ts"],

--- a/packages/stash-it/package.json
+++ b/packages/stash-it/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stash-it/stash-it",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/stash-it/src/index.test.ts
+++ b/packages/stash-it/src/index.test.ts
@@ -36,7 +36,7 @@ describe("stash-it class", () => {
     });
   });
 
-  describe("buildKey hook", () => {
+  describe("buildKey method", () => {
     describe("when a hook handler is registered for buildKey hook", () => {
       it("should be used to build the key", async () => {
         const buildKeyHookHandler = vi.fn().mockImplementationOnce((args) => Promise.resolve(args));
@@ -72,6 +72,17 @@ describe("stash-it class", () => {
 
       expect(adapter.setItem).toHaveBeenCalledWith(key, value, extra);
       expect(itemSet).toEqual(item);
+    });
+
+    it("should connect to the storage, perform the action on the adapter, and disconnect afterwards", async () => {
+      const adapter = createDummyAdapter();
+      const stashIt = new StashIt(adapter);
+
+      await stashIt.setItem(key, value, extra);
+
+      expect(adapter.connect).toHaveBeenCalledBefore(adapter.setItem);
+      expect(adapter.setItem).toHaveBeenCalledBefore(adapter.disconnect);
+      expect(adapter.disconnect).toHaveBeenCalledAfter(adapter.setItem);
     });
 
     it("flow of data through hooks", async () => {
@@ -160,6 +171,17 @@ describe("stash-it class", () => {
 
         expect(item).toBeUndefined();
       });
+    });
+
+    it("should connect to the storage, perform the action on the adapter, and disconnect afterwards", async () => {
+      const adapter = createDummyAdapter();
+      const stashIt = new StashIt(adapter);
+
+      await stashIt.getItem(key);
+
+      expect(adapter.connect).toHaveBeenCalledBefore(adapter.getItem);
+      expect(adapter.getItem).toHaveBeenCalledBefore(adapter.disconnect);
+      expect(adapter.disconnect).toHaveBeenCalledAfter(adapter.getItem);
     });
 
     it("flow of data through hooks", async () => {
@@ -251,6 +273,17 @@ describe("stash-it class", () => {
       });
     });
 
+    it("should connect to the storage, perform the action on the adapter, and disconnect afterwards", async () => {
+      const adapter = createDummyAdapter();
+      const stashIt = new StashIt(adapter);
+
+      await stashIt.hasItem(key);
+
+      expect(adapter.connect).toHaveBeenCalledBefore(adapter.hasItem);
+      expect(adapter.hasItem).toHaveBeenCalledBefore(adapter.disconnect);
+      expect(adapter.disconnect).toHaveBeenCalledAfter(adapter.hasItem);
+    });
+
     it("flow of data through hooks", async () => {
       const buildKeyHookHandler = vi.fn().mockResolvedValueOnce({ key: "buildKey-key" });
       const beforeHasItemHookHandler = vi.fn().mockResolvedValueOnce({ key: "beforeHasItem-key" });
@@ -332,6 +365,17 @@ describe("stash-it class", () => {
       });
     });
 
+    it("should connect to the storage, perform the action on the adapter, and disconnect afterwards", async () => {
+      const adapter = createDummyAdapter();
+      const stashIt = new StashIt(adapter);
+
+      await stashIt.removeItem(key);
+
+      expect(adapter.connect).toHaveBeenCalledBefore(adapter.removeItem);
+      expect(adapter.removeItem).toHaveBeenCalledBefore(adapter.disconnect);
+      expect(adapter.disconnect).toHaveBeenCalledAfter(adapter.removeItem);
+    });
+
     it("flow of data through hooks", async () => {
       const buildKeyHookHandler = vi.fn().mockResolvedValueOnce({ key: "buildKey-key" });
       const beforeRemoveItemHookHandler = vi.fn().mockResolvedValueOnce({ key: "beforeRemoveItem-key" });
@@ -400,6 +444,17 @@ describe("stash-it class", () => {
 
         expect(extraSet).toBe(false);
       });
+    });
+
+    it("should connect to the storage, perform the action on the adapter, and disconnect afterwards", async () => {
+      const adapter = createDummyAdapter();
+      const stashIt = new StashIt(adapter);
+
+      await stashIt.setExtra(key, extra);
+
+      expect(adapter.connect).toHaveBeenCalledBefore(adapter.setExtra);
+      expect(adapter.setExtra).toHaveBeenCalledBefore(adapter.disconnect);
+      expect(adapter.disconnect).toHaveBeenCalledAfter(adapter.setExtra);
     });
 
     it("flow of data through hooks", async () => {
@@ -472,6 +527,17 @@ describe("stash-it class", () => {
 
         expect(extraRetrieved).toBeUndefined();
       });
+    });
+
+    it("should connect to the storage, perform the action on the adapter, and disconnect afterwards", async () => {
+      const adapter = createDummyAdapter();
+      const stashIt = new StashIt(adapter);
+
+      await stashIt.getExtra(key);
+
+      expect(adapter.connect).toHaveBeenCalledBefore(adapter.getExtra);
+      expect(adapter.getExtra).toHaveBeenCalledBefore(adapter.disconnect);
+      expect(adapter.disconnect).toHaveBeenCalledAfter(adapter.getExtra);
     });
 
     it("flow of data through hooks", async () => {

--- a/packages/stash-it/src/index.test.ts
+++ b/packages/stash-it/src/index.test.ts
@@ -36,8 +36,8 @@ describe("stash-it class", () => {
     });
   });
 
-  describe("buildKey method", () => {
-    describe("when a hook handler is registered for buildKey hook", () => {
+  describe("buildKey hook", () => {
+    describe("when a handler is registered for buildKey hook", () => {
       it("should be used to build the key", async () => {
         const buildKeyHookHandler = vi.fn().mockImplementationOnce((args) => Promise.resolve(args));
         const plugin: StashItPlugin = {

--- a/packages/stash-it/src/index.test.ts
+++ b/packages/stash-it/src/index.test.ts
@@ -85,6 +85,30 @@ describe("stash-it class", () => {
       expect(adapter.disconnect).toHaveBeenCalledAfter(adapter.setItem);
     });
 
+    describe("error handling", () => {
+      describe("when one of the hook handlers throws", () => {
+        it("adapter disconnects, and error is rethrown", () => {
+          const plugin: StashItPlugin = {
+            hookHandlers: {
+              afterSetItem: () => {
+                throw new Error("Something went wrong...");
+              },
+            },
+          };
+
+          const adapter = createDummyAdapter();
+          const stashIt = new StashIt(adapter);
+          stashIt.registerPlugins([plugin]);
+
+          stashIt.setItem("any_key", "any_value").catch((error) => {
+            expect(error.message).toEqual("Something went wrong...");
+            expect(adapter.disconnect).toHaveBeenCalled();
+            expect(adapter.disconnect).toHaveBeenCalledAfter(adapter.setItem);
+          });
+        });
+      });
+    });
+
     it("flow of data through hooks", async () => {
       const buildKeyHookHandler = vi.fn().mockResolvedValueOnce({ key: "buildKey-key" });
       const beforeSetItemHookHandler = vi.fn().mockResolvedValueOnce({
@@ -184,6 +208,30 @@ describe("stash-it class", () => {
       expect(adapter.disconnect).toHaveBeenCalledAfter(adapter.getItem);
     });
 
+    describe("error handling", () => {
+      describe("when one of the hook handlers throws", () => {
+        it("adapter disconnects, and error is rethrown", () => {
+          const plugin: StashItPlugin = {
+            hookHandlers: {
+              afterGetItem: () => {
+                throw new Error("Something went wrong...");
+              },
+            },
+          };
+
+          const adapter = createDummyAdapter();
+          const stashIt = new StashIt(adapter);
+          stashIt.registerPlugins([plugin]);
+
+          stashIt.getItem("any_key").catch((error) => {
+            expect(error.message).toEqual("Something went wrong...");
+            expect(adapter.disconnect).toHaveBeenCalled();
+            expect(adapter.disconnect).toHaveBeenCalledAfter(adapter.getItem);
+          });
+        });
+      });
+    });
+
     it("flow of data through hooks", async () => {
       const buildKeyHookHandler = vi.fn().mockResolvedValueOnce({ key: "buildKey-key" });
       const beforeGetItemHookHandler = vi.fn().mockResolvedValueOnce({ key: "beforeGetItem-key" });
@@ -270,6 +318,30 @@ describe("stash-it class", () => {
         const result = await stashIt.hasItem(key);
 
         expect(result).toBe(false);
+      });
+    });
+
+    describe("error handling", () => {
+      describe("when one of the hook handlers throws", () => {
+        it("adapter disconnects, and error is rethrown", () => {
+          const plugin: StashItPlugin = {
+            hookHandlers: {
+              afterHasItem: () => {
+                throw new Error("Something went wrong...");
+              },
+            },
+          };
+
+          const adapter = createDummyAdapter();
+          const stashIt = new StashIt(adapter);
+          stashIt.registerPlugins([plugin]);
+
+          stashIt.hasItem("any_key").catch((error) => {
+            expect(error.message).toEqual("Something went wrong...");
+            expect(adapter.disconnect).toHaveBeenCalled();
+            expect(adapter.disconnect).toHaveBeenCalledAfter(adapter.hasItem);
+          });
+        });
       });
     });
 
@@ -376,6 +448,30 @@ describe("stash-it class", () => {
       expect(adapter.disconnect).toHaveBeenCalledAfter(adapter.removeItem);
     });
 
+    describe("error handling", () => {
+      describe("when one of the hook handlers throws", () => {
+        it("adapter disconnects, and error is rethrown", () => {
+          const plugin: StashItPlugin = {
+            hookHandlers: {
+              afterRemoveItem: () => {
+                throw new Error("Something went wrong...");
+              },
+            },
+          };
+
+          const adapter = createDummyAdapter();
+          const stashIt = new StashIt(adapter);
+          stashIt.registerPlugins([plugin]);
+
+          stashIt.removeItem("any_key").catch((error) => {
+            expect(error.message).toEqual("Something went wrong...");
+            expect(adapter.disconnect).toHaveBeenCalled();
+            expect(adapter.disconnect).toHaveBeenCalledAfter(adapter.removeItem);
+          });
+        });
+      });
+    });
+
     it("flow of data through hooks", async () => {
       const buildKeyHookHandler = vi.fn().mockResolvedValueOnce({ key: "buildKey-key" });
       const beforeRemoveItemHookHandler = vi.fn().mockResolvedValueOnce({ key: "beforeRemoveItem-key" });
@@ -455,6 +551,30 @@ describe("stash-it class", () => {
       expect(adapter.connect).toHaveBeenCalledBefore(adapter.setExtra);
       expect(adapter.setExtra).toHaveBeenCalledBefore(adapter.disconnect);
       expect(adapter.disconnect).toHaveBeenCalledAfter(adapter.setExtra);
+    });
+
+    describe("error handling", () => {
+      describe("when one of the hook handlers throws", () => {
+        it("adapter disconnects, and error is rethrown", () => {
+          const plugin: StashItPlugin = {
+            hookHandlers: {
+              afterSetExtra: () => {
+                throw new Error("Something went wrong...");
+              },
+            },
+          };
+
+          const adapter = createDummyAdapter();
+          const stashIt = new StashIt(adapter);
+          stashIt.registerPlugins([plugin]);
+
+          stashIt.setExtra("any_key", { some: "extra" }).catch((error) => {
+            expect(error.message).toEqual("Something went wrong...");
+            expect(adapter.disconnect).toHaveBeenCalled();
+            expect(adapter.disconnect).toHaveBeenCalledAfter(adapter.setExtra);
+          });
+        });
+      });
     });
 
     it("flow of data through hooks", async () => {
@@ -538,6 +658,30 @@ describe("stash-it class", () => {
       expect(adapter.connect).toHaveBeenCalledBefore(adapter.getExtra);
       expect(adapter.getExtra).toHaveBeenCalledBefore(adapter.disconnect);
       expect(adapter.disconnect).toHaveBeenCalledAfter(adapter.getExtra);
+    });
+
+    describe("error handling", () => {
+      describe("when one of the hook handlers throws", () => {
+        it("adapter disconnects, and error is rethrown", () => {
+          const plugin: StashItPlugin = {
+            hookHandlers: {
+              afterGetExtra: () => {
+                throw new Error("Something went wrong...");
+              },
+            },
+          };
+
+          const adapter = createDummyAdapter();
+          const stashIt = new StashIt(adapter);
+          stashIt.registerPlugins([plugin]);
+
+          stashIt.getExtra("any_key").catch((error) => {
+            expect(error.message).toEqual("Something went wrong...");
+            expect(adapter.disconnect).toHaveBeenCalled();
+            expect(adapter.disconnect).toHaveBeenCalledAfter(adapter.getExtra);
+          });
+        });
+      });
     });
 
     it("flow of data through hooks", async () => {

--- a/packages/stash-it/src/index.ts
+++ b/packages/stash-it/src/index.ts
@@ -49,79 +49,115 @@ export class StashIt implements StashItInterface {
 
     await this.#adapter.connect();
 
-    const builtKey = await this.#buildKey(key);
-    const beforeData = await this.#call("beforeSetItem", { key: builtKey, value, extra });
-    const setItem = await this.#adapter.setItem(beforeData.key, beforeData.value, beforeData.extra);
-    const afterData = await this.#call("afterSetItem", { ...beforeData, item: setItem });
+    try {
+      const builtKey = await this.#buildKey(key);
+      const beforeData = await this.#call("beforeSetItem", { key: builtKey, value, extra });
+      const setItem = await this.#adapter.setItem(beforeData.key, beforeData.value, beforeData.extra);
+      const afterData = await this.#call("afterSetItem", { ...beforeData, item: setItem });
 
-    await this.#adapter.disconnect();
+      await this.#adapter.disconnect();
 
-    return afterData.item;
+      return afterData.item;
+    } catch (error) {
+      await this.#adapter.disconnect();
+
+      throw error;
+    }
   }
 
   async getItem(key: Key): Promise<GetItemResult> {
     await this.#adapter.connect();
 
-    const builtKey = await this.#buildKey(key);
-    const beforeData = await this.#call("beforeGetItem", { key: builtKey });
-    const item = await this.#adapter.getItem(beforeData.key);
-    const afterData = await this.#call("afterGetItem", { ...beforeData, item });
+    try {
+      const builtKey = await this.#buildKey(key);
+      const beforeData = await this.#call("beforeGetItem", { key: builtKey });
+      const item = await this.#adapter.getItem(beforeData.key);
+      const afterData = await this.#call("afterGetItem", { ...beforeData, item });
 
-    await this.#adapter.disconnect();
+      await this.#adapter.disconnect();
 
-    return afterData.item;
+      return afterData.item;
+    } catch (error) {
+      await this.#adapter.disconnect();
+
+      throw error;
+    }
   }
 
   async hasItem(key: Key): Promise<boolean> {
     await this.#adapter.connect();
 
-    const builtKey = await this.#buildKey(key);
-    const beforeData = await this.#call("beforeHasItem", { key: builtKey });
-    const result = await this.#adapter.hasItem(beforeData.key);
-    const afterData = await this.#call("afterHasItem", { ...beforeData, result });
+    try {
+      const builtKey = await this.#buildKey(key);
+      const beforeData = await this.#call("beforeHasItem", { key: builtKey });
+      const result = await this.#adapter.hasItem(beforeData.key);
+      const afterData = await this.#call("afterHasItem", { ...beforeData, result });
 
-    await this.#adapter.disconnect();
+      await this.#adapter.disconnect();
 
-    return afterData.result;
+      return afterData.result;
+    } catch (error) {
+      await this.#adapter.disconnect();
+
+      throw error;
+    }
   }
 
   async removeItem(key: Key): Promise<boolean> {
     await this.#adapter.connect();
 
-    const builtKey = await this.#buildKey(key);
-    const beforeData = await this.#call("beforeRemoveItem", { key: builtKey });
-    const result = await this.#adapter.removeItem(beforeData.key);
-    const afterData = await this.#call("afterRemoveItem", { ...beforeData, result });
+    try {
+      const builtKey = await this.#buildKey(key);
+      const beforeData = await this.#call("beforeRemoveItem", { key: builtKey });
+      const result = await this.#adapter.removeItem(beforeData.key);
+      const afterData = await this.#call("afterRemoveItem", { ...beforeData, result });
 
-    await this.#adapter.disconnect();
+      await this.#adapter.disconnect();
 
-    return afterData.result;
+      return afterData.result;
+    } catch (error) {
+      await this.#adapter.disconnect();
+
+      throw error;
+    }
   }
 
   async setExtra(key: Key, extra: Extra): Promise<SetExtraResult> {
     await this.#adapter.connect();
 
-    const builtKey = await this.#buildKey(key);
-    const beforeData = await this.#call("beforeSetExtra", { key: builtKey, extra });
-    const extraSet = await this.#adapter.setExtra(beforeData.key, beforeData.extra);
-    const afterData = await this.#call("afterSetExtra", { ...beforeData, extra: extraSet });
+    try {
+      const builtKey = await this.#buildKey(key);
+      const beforeData = await this.#call("beforeSetExtra", { key: builtKey, extra });
+      const extraSet = await this.#adapter.setExtra(beforeData.key, beforeData.extra);
+      const afterData = await this.#call("afterSetExtra", { ...beforeData, extra: extraSet });
 
-    await this.#adapter.disconnect();
+      await this.#adapter.disconnect();
 
-    return afterData.extra;
+      return afterData.extra;
+    } catch (error) {
+      await this.#adapter.disconnect();
+
+      throw error;
+    }
   }
 
   async getExtra(key: Key): Promise<GetExtraResult> {
     await this.#adapter.connect();
 
-    const builtKey = await this.#buildKey(key);
-    const beforeData = await this.#call("beforeGetExtra", { key: builtKey });
-    const extra = await this.#adapter.getExtra(beforeData.key);
-    const afterData = await this.#call("afterGetExtra", { ...beforeData, extra });
+    try {
+      const builtKey = await this.#buildKey(key);
+      const beforeData = await this.#call("beforeGetExtra", { key: builtKey });
+      const extra = await this.#adapter.getExtra(beforeData.key);
+      const afterData = await this.#call("afterGetExtra", { ...beforeData, extra });
 
-    await this.#adapter.disconnect();
+      await this.#adapter.disconnect();
 
-    return afterData.extra;
+      return afterData.extra;
+    } catch (error) {
+      await this.#adapter.disconnect();
+
+      throw error;
+    }
   }
 
   registerPlugins(plugins: StashItPlugin[]) {

--- a/packages/stash-it/src/index.ts
+++ b/packages/stash-it/src/index.ts
@@ -49,10 +49,10 @@ export class StashIt implements StashItInterface {
 
     await this.#adapter.connect();
 
-    const beforeData = await this.#call("beforeSetItem", { key, value, extra });
-    const builtKey = await this.#buildKey(beforeData.key);
-    const setItem = await this.#adapter.setItem(builtKey, beforeData.value, beforeData.extra);
-    const afterData = await this.#call("afterSetItem", { ...beforeData, key: builtKey, item: setItem });
+    const builtKey = await this.#buildKey(key);
+    const beforeData = await this.#call("beforeSetItem", { key: builtKey, value, extra });
+    const setItem = await this.#adapter.setItem(beforeData.key, beforeData.value, beforeData.extra);
+    const afterData = await this.#call("afterSetItem", { ...beforeData, item: setItem });
 
     await this.#adapter.disconnect();
 
@@ -62,10 +62,10 @@ export class StashIt implements StashItInterface {
   async getItem(key: Key): Promise<GetItemResult> {
     await this.#adapter.connect();
 
-    const beforeData = await this.#call("beforeGetItem", { key });
-    const builtKey = await this.#buildKey(beforeData.key);
-    const item = await this.#adapter.getItem(builtKey);
-    const afterData = await this.#call("afterGetItem", { ...beforeData, key: builtKey, item });
+    const builtKey = await this.#buildKey(key);
+    const beforeData = await this.#call("beforeGetItem", { key: builtKey });
+    const item = await this.#adapter.getItem(beforeData.key);
+    const afterData = await this.#call("afterGetItem", { ...beforeData, item });
 
     await this.#adapter.disconnect();
 
@@ -75,10 +75,10 @@ export class StashIt implements StashItInterface {
   async hasItem(key: Key): Promise<boolean> {
     await this.#adapter.connect();
 
-    const beforeData = await this.#call("beforeHasItem", { key });
-    const builtKey = await this.#buildKey(beforeData.key);
-    const result = await this.#adapter.hasItem(builtKey);
-    const afterData = await this.#call("afterHasItem", { ...beforeData, key: builtKey, result });
+    const builtKey = await this.#buildKey(key);
+    const beforeData = await this.#call("beforeHasItem", { key: builtKey });
+    const result = await this.#adapter.hasItem(beforeData.key);
+    const afterData = await this.#call("afterHasItem", { ...beforeData, result });
 
     await this.#adapter.disconnect();
 
@@ -88,10 +88,10 @@ export class StashIt implements StashItInterface {
   async removeItem(key: Key): Promise<boolean> {
     await this.#adapter.connect();
 
-    const beforeData = await this.#call("beforeRemoveItem", { key });
-    const builtKey = await this.#buildKey(beforeData.key);
-    const result = await this.#adapter.removeItem(builtKey);
-    const afterData = await this.#call("afterRemoveItem", { ...beforeData, key: builtKey, result });
+    const builtKey = await this.#buildKey(key);
+    const beforeData = await this.#call("beforeRemoveItem", { key: builtKey });
+    const result = await this.#adapter.removeItem(beforeData.key);
+    const afterData = await this.#call("afterRemoveItem", { ...beforeData, result });
 
     await this.#adapter.disconnect();
 
@@ -101,10 +101,10 @@ export class StashIt implements StashItInterface {
   async setExtra(key: Key, extra: Extra): Promise<SetExtraResult> {
     await this.#adapter.connect();
 
-    const beforeData = await this.#call("beforeSetExtra", { key, extra });
-    const builtKey = await this.#buildKey(beforeData.key);
-    const extraSet = await this.#adapter.setExtra(builtKey, beforeData.extra);
-    const afterData = await this.#call("afterSetExtra", { ...beforeData, key: builtKey, extra: extraSet });
+    const builtKey = await this.#buildKey(key);
+    const beforeData = await this.#call("beforeSetExtra", { key: builtKey, extra });
+    const extraSet = await this.#adapter.setExtra(beforeData.key, beforeData.extra);
+    const afterData = await this.#call("afterSetExtra", { ...beforeData, extra: extraSet });
 
     await this.#adapter.disconnect();
 
@@ -114,10 +114,10 @@ export class StashIt implements StashItInterface {
   async getExtra(key: Key): Promise<GetExtraResult> {
     await this.#adapter.connect();
 
-    const beforeData = await this.#call("beforeGetExtra", { key });
-    const builtKey = await this.#buildKey(beforeData.key);
-    const extra = await this.#adapter.getExtra(builtKey);
-    const afterData = await this.#call("afterGetExtra", { ...beforeData, key: builtKey, extra });
+    const builtKey = await this.#buildKey(key);
+    const beforeData = await this.#call("beforeGetExtra", { key: builtKey });
+    const extra = await this.#adapter.getExtra(beforeData.key);
+    const afterData = await this.#call("afterGetExtra", { ...beforeData, extra });
 
     await this.#adapter.disconnect();
 


### PR DESCRIPTION
First the key is built, then before hook handlers are called with that key built.
Then adapter gets called with data returned from before hook handlers. Finally, after hook handlers are called with data returned from calling adapter, and data returned by before hook handlers.

That is the correct way.